### PR TITLE
v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,40 @@ sts = litests.LiteSTS(
 ```
 
 
+## ⚡️ Function Calling
+
+You can use Function Calling (Tool Call) by registering function specifications and their handlers with the `ChatGPTService` instance through `register_tool`, as shown below. Functions will be automatically invoked as needed.
+
+**NOTE**: Currently, only ChatGPT is supported.
+
+```python
+# Instantiate ChatGPTService
+chatgpt = ChatGPTService(
+    openai_api_key=OPENAI_API_KEY,
+    system_prompt=SYSTEM_PROMPT
+)
+
+# Make function
+async def get_weather(location: str = None):
+    weather = await weather_api(location=location)
+    return weather  # {"weather": "clear", "temperature": 23.4}
+
+# Register spec and function
+chatgpt.register_tool({
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "location": {"type": "string"}
+            },
+        },
+    }
+}, get_weather)
+```
+
+
 ## 🧩 Make custom modules
 
 By creating modules that inherit the interfaces for VAD, STT, LLM, TTS, and the Response Handler, you can integrate them into the pipeline. Below, only the interfaces are introduced; for implementation details, please refer to the existing modules included in the repository.

--- a/litests/llm/chatgpt.py
+++ b/litests/llm/chatgpt.py
@@ -1,9 +1,17 @@
+import json
 from logging import getLogger
-from typing import AsyncGenerator, Dict, List
+from typing import AsyncGenerator, Awaitable, Callable, Dict, List
 import openai
 from . import LLMService
 
 logger = getLogger(__name__)
+
+
+class ToolCall:
+    def __init__(self, id: str, name: str):
+        self.id = id
+        self.name = name
+        self.arguments = ""
 
 
 class ChatGPTService(LLMService):
@@ -31,6 +39,9 @@ class ChatGPTService(LLMService):
         )
         self.openai_client = openai.AsyncClient(api_key=openai_api_key, base_url=base_url)
         self.contexts: List[Dict[str, List]] = {}
+        self.tools = []
+        self.tool_functions = {}
+        self.on_before_tool_calls: Callable[[List[ToolCall]], Awaitable[None]]
 
     def compose_messages(self, context_id: str, text: str) -> List[dict]:
         messages = []
@@ -46,14 +57,65 @@ class ChatGPTService(LLMService):
         messages.append({"role": "assistant", "content": response_text})
         self.contexts[context_id] = messages
 
+    def register_tool(self, tool_spec: dict, tool_function: callable):
+        tool_name = tool_spec["function"]["name"]
+        self.tools.append(tool_spec)
+        self.tool_functions[tool_name] = tool_function
+
     async def get_llm_stream_response(self, context_id: str, messages: List[dict]) -> AsyncGenerator[str, None]:
         stream_resp = await self.openai_client.chat.completions.create(
             messages=messages,
             model=self.model,
             temperature=self.temperature,
+            tools=self.tools or None,
             stream=True
         )
 
+        tool_calls: List[ToolCall] = []
         async for chunk in stream_resp:
-            if content := chunk.choices[0].delta.content:
+            if chunk.choices[0].delta.tool_calls:
+                t = chunk.choices[0].delta.tool_calls[0]
+                if t.id:
+                    tool_calls.append(ToolCall(t.id, t.function.name))
+                if t.function.arguments:
+                    tool_calls[-1].arguments += t.function.arguments
+
+            elif content := chunk.choices[0].delta.content:
                 yield content
+
+        if tool_calls:
+            # Add user message to context
+            if context_id not in self.contexts:
+                self.contexts[context_id] = []
+            self.contexts[context_id].append(messages[-1])
+
+            # Do something before tool calls (e.g. say to user that it will take a long time)
+            if self.on_before_tool_calls:
+                await self.on_before_tool_calls(tool_calls)
+
+            # Execute tools
+            for tc in tool_calls:
+                tool_result = await self.tool_functions[tc.name](**(json.loads(tc.arguments)))
+
+                messages.append({
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.name,
+                            "arguments": tc.arguments
+                        }
+                    }]
+                })
+                self.contexts[context_id].append(messages[-1])
+
+                messages.append({
+                    "role": "tool",
+                    "content": json.dumps(tool_result),
+                    "tool_call_id": tc.id
+                })
+                self.contexts[context_id].append(messages[-1])
+
+            async for chunk in self.get_llm_stream_response(context_id, messages):
+                yield chunk

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="litests",
-    version="0.1.1",
+    version="0.1.2",
     url="https://github.com/uezo/litests",
     author="uezo",
     author_email="uezo@uezo.net",


### PR DESCRIPTION
## ⚡️ Function Calling

Add support for ChatGPT Function calling #8 

You can use Function Calling (Tool Call) by registering function specifications and their handlers with the `ChatGPTService` instance through `register_tool`, as shown below. Functions will be automatically invoked as needed.

**NOTE**: Currently, only ChatGPT is supported.

```python
# Instantiate ChatGPTService
chatgpt = ChatGPTService(
    openai_api_key=OPENAI_API_KEY,
    system_prompt=SYSTEM_PROMPT
)

# Make function
async def get_weather(location: str = None):
    weather = await weather_api(location=location)
    return weather  # {"weather": "clear", "temperature": 23.4}

# Register spec and function
chatgpt.register_tool({
    "type": "function",
    "function": {
        "name": "get_weather",
        "parameters": {
            "type": "object",
            "properties": {
                "location": {"type": "string"}
            },
        },
    }
}, get_weather)
```