### PR TITLE
Enable persistent context storage instead of in-memory

### DIFF
--- a/litests/llm/__init__.py
+++ b/litests/llm/__init__.py
@@ -1,1 +1,1 @@
-from .base import LLMService, LLMResponse
+from .base import LLMService, LLMResponse, ContextManager, SQLiteContextManager

--- a/litests/llm/chatgpt.py
+++ b/litests/llm/chatgpt.py
@@ -2,7 +2,7 @@ import json
 from logging import getLogger
 from typing import AsyncGenerator, Awaitable, Callable, Dict, List
 import openai
-from . import LLMService
+from . import LLMService, ContextManager
 
 logger = getLogger(__name__)
 
@@ -26,7 +26,8 @@ class ChatGPTService(LLMService):
         split_chars: List[str] = None,
         option_split_chars: List[str] = None,
         option_split_threshold: int = 50,
-        skip_before: str = None
+        skip_before: str = None,
+        context_manager: ContextManager = None
     ):
         super().__init__(
             system_prompt=system_prompt,
@@ -35,35 +36,38 @@ class ChatGPTService(LLMService):
             split_chars=split_chars,
             option_split_chars=option_split_chars,
             option_split_threshold=option_split_threshold,
-            skip_before=skip_before
+            skip_before=skip_before,
+            context_manager=context_manager
         )
         self.openai_client = openai.AsyncClient(api_key=openai_api_key, base_url=base_url)
-        self.contexts: List[Dict[str, List]] = {}
         self.tools = []
         self.tool_functions = {}
         self.on_before_tool_calls: Callable[[List[ToolCall]], Awaitable[None]] = None
 
-    def compose_messages(self, context_id: str, text: str) -> List[dict]:
+    async def compose_messages(self, context_id: str, text: str) -> List[Dict]:
         messages = []
         if self.system_prompt:
             messages.append({"role": "system", "content": self.system_prompt})
-        messages.extend(self.contexts.get(context_id, []))
+
+        # Extract the history starting from the first message where the role is 'user'
+        histories = await self.context_manager.get_histories(context_id)
+        while histories and histories["role"] != "user":
+            histories.pop(0)
+        messages.extend(histories)
+
         messages.append({"role": "user", "content": text})
         return messages
 
-    def update_context(self, context_id: str, request_text: str, response_text: str):
-        messages = self.contexts.get(context_id, [])
-        if len(messages) == 0 or messages[-1]["role"] != "tool":
-            messages.append({"role": "user", "content": request_text})
+    async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
         messages.append({"role": "assistant", "content": response_text})
-        self.contexts[context_id] = messages
+        await self.context_manager.add_histories(context_id, messages, "chatgpt")
 
     def register_tool(self, tool_spec: dict, tool_function: callable):
         tool_name = tool_spec["function"]["name"]
         self.tools.append(tool_spec)
         self.tool_functions[tool_name] = tool_function
 
-    async def get_llm_stream_response(self, context_id: str, messages: List[dict]) -> AsyncGenerator[str, None]:
+    async def get_llm_stream_response(self, context_id: str, messages: List[Dict]) -> AsyncGenerator[str, None]:
         stream_resp = await self.openai_client.chat.completions.create(
             messages=messages,
             model=self.model,
@@ -85,13 +89,6 @@ class ChatGPTService(LLMService):
                 yield content
 
         if tool_calls:
-            if context_id not in self.contexts:
-                self.contexts[context_id] = []
-            
-            # Add user message to context
-            if messages[-1]["role"] != "tool":
-                self.contexts[context_id].append(messages[-1])
-
             # Do something before tool calls (e.g. say to user that it will take a long time)
             if self.on_before_tool_calls:
                 await self.on_before_tool_calls(tool_calls)
@@ -111,14 +108,12 @@ class ChatGPTService(LLMService):
                         }
                     }]
                 })
-                self.contexts[context_id].append(messages[-1])
 
                 messages.append({
                     "role": "tool",
                     "content": json.dumps(tool_result),
                     "tool_call_id": tc.id
                 })
-                self.contexts[context_id].append(messages[-1])
 
             async for chunk in self.get_llm_stream_response(context_id, messages):
                 yield chunk

--- a/litests/llm/dify.py
+++ b/litests/llm/dify.py
@@ -48,7 +48,7 @@ class DifyService(LLMService):
             )
         )
 
-    def compose_messages(self, context_id: str, text: str) -> List[dict]:
+    async def compose_messages(self, context_id: str, text: str) -> List[Dict]:
         if self.make_inputs:
             inputs = self.make_inputs(context_id, text)
         else:
@@ -63,9 +63,10 @@ class DifyService(LLMService):
             "conversation_id": self.conversation_ids.get(context_id, "")
         }]
 
-    def update_context(self, context_id: str, request_text: str, response_text: str):
+    async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
         # Context is managed at Dify server
         pass
+
 
     async def get_llm_stream_response(self, context_id: str, messages: List[dict]) -> AsyncGenerator[str, None]:
         headers = {

--- a/tests/llm/test_chatgpt.py
+++ b/tests/llm/test_chatgpt.py
@@ -2,6 +2,7 @@ import json
 import os
 import pytest
 from typing import Any, Dict
+from uuid import uuid4
 from litests.llm.chatgpt import ChatGPTService, ToolCall
 
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -47,7 +48,7 @@ async def test_chatgpt_service_simple():
         model=MODEL,
         temperature=0.5
     )
-    context_id = "test_context"
+    context_id = f"test_context_{uuid4()}"
 
     user_message = "君が大切にしていたプリンは、私が勝手に食べておいた。"
 
@@ -67,8 +68,7 @@ async def test_chatgpt_service_simple():
     assert "[face:Angry]" not in full_voice, "Control tag was not removed from voice_text."
 
     # Check the context
-    assert context_id in service.contexts
-    messages = service.contexts[context_id]
+    messages = await service.context_manager.get_histories(context_id)
     assert any(m["role"] == "user" for m in messages), "User message not found in context."
     assert any(m["role"] == "assistant" for m in messages), "Assistant message not found in context."
 
@@ -88,7 +88,7 @@ async def test_chatgpt_service_cot():
         temperature=0.5,
         skip_before="<answer>"
     )
-    context_id = "test_context"
+    context_id = f"test_cot_context_{uuid4()}"
 
     user_message = "君が大切にしていたプリンは、私が勝手に食べておいた。"
 
@@ -114,8 +114,7 @@ async def test_chatgpt_service_cot():
     assert "</answer>" not in full_voice, "Answer tag closing was not removed from voice_text."
 
     # Check the context
-    assert context_id in service.contexts
-    messages = service.contexts[context_id]
+    messages = await service.context_manager.get_histories(context_id)
     assert any(m["role"] == "user" for m in messages), "User message not found in context."
     assert any(m["role"] == "assistant" for m in messages), "Assistant message not found in context."
 
@@ -135,7 +134,7 @@ async def test_chatgpt_service_tool_calls():
         model=MODEL,
         temperature=0.5
     )
-    context_id = "test_context_tool"
+    context_id = f"test_tool_context_{uuid4()}"
 
     # Tool
     async def solve_math(problem: str) -> Dict[str, Any]:
@@ -175,7 +174,7 @@ async def test_chatgpt_service_tool_calls():
         collected_text.append(resp.text)
 
     # Check context
-    messages = service.contexts[context_id]
+    messages = await service.context_manager.get_histories(context_id)
     assert len(messages) == 4
 
     assert messages[0]["role"] == "user"

--- a/tests/llm/test_claude.py
+++ b/tests/llm/test_claude.py
@@ -1,6 +1,7 @@
 import json
 import os
 from typing import Any, Dict
+from uuid import uuid4
 import pytest
 from litests.llm.claude import ClaudeService
 
@@ -47,7 +48,7 @@ async def test_claude_service_simple():
         model=MODEL,
         temperature=0.5
     )
-    context_id = "test_context"
+    context_id = f"test_context_{uuid4()}"
 
     user_message = "君が大切にしていたプリンは、私が勝手に食べておいた。"
 
@@ -67,8 +68,7 @@ async def test_claude_service_simple():
     assert "[face:Angry]" not in full_voice, "Control tag was not removed from voice_text."
 
     # Check the context
-    assert context_id in service.contexts
-    messages = service.contexts[context_id]
+    messages = await service.context_manager.get_histories(context_id)
     assert any(m["role"] == "user" for m in messages), "User message not found in context."
     assert any(m["role"] == "assistant" for m in messages), "Assistant message not found in context."
 
@@ -86,7 +86,7 @@ async def test_claude_service_cot():
         temperature=0.5,
         skip_before="<answer>"
     )
-    context_id = "test_context"
+    context_id = f"test_context_cot_{uuid4()}"
 
     user_message = "君が大切にしていたプリンは、私が勝手に食べておいた。"
 
@@ -112,14 +112,13 @@ async def test_claude_service_cot():
     assert "</answer>" not in full_voice, "Answer tag closing was not removed from voice_text."
 
     # Check the context
-    assert context_id in service.contexts
-    messages = service.contexts[context_id]
+    messages = await service.context_manager.get_histories(context_id)
     assert any(m["role"] == "user" for m in messages), "User message not found in context."
     assert any(m["role"] == "assistant" for m in messages), "Assistant message not found in context."
 
 
 @pytest.mark.asyncio
-async def test_chatgpt_service_tool_calls():
+async def test_claude_service_tool_calls():
     """
     Test ClaudeService with a registered tool.
     The conversation might trigger the tool call, then the tool's result is fed back.
@@ -131,7 +130,7 @@ async def test_chatgpt_service_tool_calls():
         model=MODEL,
         temperature=0.5
     )
-    context_id = "test_context_tool"
+    context_id = f"test_context_tool_{uuid4()}"
 
     # Tool
     async def solve_math(problem: str) -> Dict[str, Any]:
@@ -164,7 +163,7 @@ async def test_chatgpt_service_tool_calls():
         collected_text.append(resp.text)
 
     # Check context
-    messages = service.contexts[context_id]
+    messages = await service.context_manager.get_histories(context_id)
     assert len(messages) == 4
 
     assert messages[0]["role"] == "user"

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -1,6 +1,7 @@
 import json
 import os
 from typing import Any, Dict
+from uuid import uuid4
 import pytest
 from litests.llm.litellm import LiteLLMService
 
@@ -47,7 +48,7 @@ async def test_litellm_service_simple():
         model=MODEL,
         temperature=0.5
     )
-    context_id = "test_context"
+    context_id = f"test_context_{uuid4()}"
 
     user_message = "君が大切にしていたプリンは、私が勝手に食べておいた。"
 
@@ -67,8 +68,7 @@ async def test_litellm_service_simple():
     assert "[face:Angry]" not in full_voice, "Control tag was not removed from voice_text."
 
     # Check the context
-    assert context_id in service.contexts
-    messages = service.contexts[context_id]
+    messages = await service.context_manager.get_histories(context_id)
     assert any(m["role"] == "user" for m in messages), "User message not found in context."
     assert any(m["role"] == "assistant" for m in messages), "Assistant message not found in context."
 
@@ -86,7 +86,7 @@ async def test_litellm_service_cot():
         temperature=0.5,
         skip_before="<answer>"
     )
-    context_id = "test_context"
+    context_id = f"test_context_cot_{uuid4()}"
 
     user_message = "君が大切にしていたプリンは、私が勝手に食べておいた。"
 
@@ -112,8 +112,7 @@ async def test_litellm_service_cot():
     assert "</answer>" not in full_voice, "Answer tag closing was not removed from voice_text."
 
     # Check the context
-    assert context_id in service.contexts
-    messages = service.contexts[context_id]
+    messages = await service.context_manager.get_histories(context_id)
     assert any(m["role"] == "user" for m in messages), "User message not found in context."
     assert any(m["role"] == "assistant" for m in messages), "Assistant message not found in context."
 
@@ -131,7 +130,7 @@ async def test_litellm_service_tool_calls():
         model=MODEL,
         temperature=0.5,
     )
-    context_id = "test_context_tool"
+    context_id = f"test_context_tool_{uuid4()}"
 
     # Tool
     async def solve_math(problem: str) -> Dict[str, Any]:
@@ -167,7 +166,7 @@ async def test_litellm_service_tool_calls():
         collected_text.append(resp.text)
 
     # Check context
-    messages = service.contexts[context_id]
+    messages = await service.context_manager.get_histories(context_id)
     assert len(messages) == 4
 
     assert messages[0]["role"] == "user"


### PR DESCRIPTION
- Replaced in-memory List-based chat history storage with a new ContextManager class.
- ContextManager uses SQLite as the default storage backend, enabling persistent chat history across program restarts.
- Added default expiration for chat history entries, set to 3600 seconds.
- No changes to the external API or usage; the update is an internal refactor for improved data management and persistence.