### PR TITLE
Make session_id required for conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ async def quick_start_main():
         debug=True
     )
 
-    await start_with_pyaudio(sts.vad)
+    await start_with_pyaudio("session_id", sts.vad)
 
 asyncio.run(quick_start_main())
 ```

--- a/examples/local/llms.py
+++ b/examples/local/llms.py
@@ -52,6 +52,6 @@ async def quick_start_main():
         debug=True
     )
 
-    await start_with_pyaudio(sts.vad)
+    await start_with_pyaudio("session_id", sts.vad)
 
 asyncio.run(quick_start_main())

--- a/examples/local/run.py
+++ b/examples/local/run.py
@@ -14,6 +14,6 @@ async def quick_start_main():
         debug=True
     )
 
-    await start_with_pyaudio(sts.vad)
+    await start_with_pyaudio("session_id", sts.vad)
 
 asyncio.run(quick_start_main())

--- a/litests/vad/microphone_connector.py
+++ b/litests/vad/microphone_connector.py
@@ -6,6 +6,7 @@ logger = getLogger(__name__)
 
 
 async def start_with_pyaudio(
+    session_id: str,
     vad: StandardSpeechDetector,
     sample_rate: int = 16000,
     channels: int = 1,
@@ -32,16 +33,17 @@ async def start_with_pyaudio(
         data = await loop.run_in_executor(None, pyaudio_stream.read, chunk_size)
         if not data:
             break
-        await vad.process_samples(data)
+        await vad.process_samples(data, session_id)
         await asyncio.sleep(0.0001)
 
     # Finalize
-    vad.delete_session(vad.DEFAULT_SESSION_ID)
+    vad.delete_session(session_id)
 
     logger.info("LiteSTS finish listening. (pyaudio)")
 
 
 async def start_with_sounddevice(
+    session_id: str,
     vad: StandardSpeechDetector,
     sample_rate: int = 16000,
     channels: int = 1,
@@ -73,10 +75,10 @@ async def start_with_sounddevice(
             break
 
         audio_bytes = numpy.int16(data * 32767).tobytes()
-        await vad.process_samples(audio_bytes)
+        await vad.process_samples(audio_bytes, session_id)
         await asyncio.sleep(0.0001)
 
     # Finalize
-    vad.delete_session(vad.DEFAULT_SESSION_ID)
+    vad.delete_session(session_id)
 
     logger.info("LiteSTS finish listening. (sounddevice)")

--- a/litests/vad/standard.py
+++ b/litests/vad/standard.py
@@ -27,8 +27,6 @@ class RecordingSession:
 
 
 class StandardSpeechDetector(SpeechDetector):
-    DEFAULT_SESSION_ID = "DEFAULT_SESSION"
-
     def __init__(
         self,
         *,
@@ -74,7 +72,7 @@ class StandardSpeechDetector(SpeechDetector):
         except Exception as ex:
             logger.error(f"Error in task for session {session_id}: {ex}", exc_info=True)
 
-    async def process_samples(self, samples: bytes, session_id: str = DEFAULT_SESSION_ID):
+    async def process_samples(self, samples: bytes, session_id: str):
         if self.to_linear16:
             samples = self.to_linear16(samples)
 
@@ -138,7 +136,7 @@ class StandardSpeechDetector(SpeechDetector):
                     logger.info(f"Recording too long: {session.record_duration} sec")
                 session.reset()
 
-    async def process_stream(self, input_stream: AsyncGenerator[bytes, None], session_id: str = DEFAULT_SESSION_ID):
+    async def process_stream(self, input_stream: AsyncGenerator[bytes, None], session_id: str):
         logger.info("LiteSTS start processing stream.")
 
         async for data in input_stream:


### PR DESCRIPTION
- Previously, message history was managed in memory, allowing new conversations to start with the default session ID upon app restart.
- With the switch to database-based history management, a session ID is now required to distinguish and initiate new conversations.