### PR TITLE
Make PyAudio optional in installation requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ A super lightweight Speech-to-Speech framework with modular VAD, STT, LLM and TT
 
 ## 🎁 Installation
 
-You can install it with a single `pip` command. Since `PyAudio` internally uses `PortAudio`, you'll need to install it beforehand.
+You can install it with a single `pip` command:
 
 ```sh
 pip install git+https://github.com/uezo/litests
 ```
 
-If you use LiteSTS with your microphone on your local computer, install `PortAudio` and its binding `PyAudio` beforehand.
+If you plan to use LiteSTS to handle microphone input or play audio on a local computer, make sure to install `PortAudio` and its Python binding, `PyAudio`, beforehand:
 
 ```sh
 # Mac

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 httpx==0.27.0
 openai>=1.55.3
-PyAudio>=0.2.14

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="litests",
-    version="0.1.4",
+    version="0.1.5",
     url="https://github.com/uezo/litests",
     author="uezo",
     author_email="uezo@uezo.net",
@@ -12,7 +12,7 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     packages=find_packages(exclude=["tests*"]),
-    install_requires=["httpx==0.27.0", "openai>=1.55.3", "PyAudio>=0.2.14"],
+    install_requires=["httpx==0.27.0", "openai>=1.55.3"],
     license="Apache v2",
     classifiers=[
         "Programming Language :: Python :: 3"


### PR DESCRIPTION
PyAudio is now treated as optional because server-side use cases, such as receiving data via WebSocket, do not require microphone input or audio playback.