### PR TITLE
Switch to tag-based voice text extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,30 @@ async def get_weather(location: str = None):
     return weather  # {"weather": "clear", "temperature": 23.4}
 ```
 
+
+## ⛓️ Chain of Thought Prompting
+
+Chain of Thought Prompting (CoT) is one of the popular techniques to improve the quality of AI responses. LiteSTS, by default, directly synthesize AI output, but it can also be configured to synthesize only the text inside specific XML tags.
+
+For example, if you want the AI to output its thought process inside `<thinking>~</thinking>` and the final speech content inside `<answer>~</answer>`, you can use the following sample code:
+
+```python
+SYSTEM_PROMPT = """
+Carefully consider the response first.
+Output your thought process inside <thinking>~</thinking>.
+Then, output the content to be spoken inside <answer>~</answer>.
+"""
+
+service = ChatGPTService(
+    openai_api_key=OPENAI_API_KEY,
+    system_prompt=SYSTEM_PROMPT,
+    model="gpt-4o",
+    temperature=0.5,
+    voice_text_tag="answer" # <- Synthesize inner text of <answer> tag
+)
+```
+
+
 ## 🪄 Request Filter
 
 You can validate and preprocess requests (recognized text from voice) before they are sent to LLM.
@@ -191,7 +215,6 @@ You can validate and preprocess requests (recognized text from voice) before the
 chatgpt = ChatGPTService(
     openai_api_key=OPENAI_API_KEY,
     system_prompt=SYSTEM_PROMPT,
-    skip_before="<answer>",
     debug = True
 )
 

--- a/litests/llm/chatgpt.py
+++ b/litests/llm/chatgpt.py
@@ -21,7 +21,7 @@ class ChatGPTService(LLMService):
         split_chars: List[str] = None,
         option_split_chars: List[str] = None,
         option_split_threshold: int = 50,
-        skip_before: str = None,
+        voice_text_tag: str = None,
         context_manager: ContextManager = None,
         debug: bool = False
     ):
@@ -32,7 +32,7 @@ class ChatGPTService(LLMService):
             split_chars=split_chars,
             option_split_chars=option_split_chars,
             option_split_threshold=option_split_threshold,
-            skip_before=skip_before,
+            voice_text_tag=voice_text_tag,
             context_manager=context_manager,
             debug=debug
         )

--- a/litests/llm/claude.py
+++ b/litests/llm/claude.py
@@ -21,7 +21,7 @@ class ClaudeService(LLMService):
         split_chars: List[str] = None,
         option_split_chars: List[str] = None,
         option_split_threshold: int = 50,
-        skip_before: str = None,
+        voice_text_tag: str = None,
         context_manager: ContextManager = None,
         debug: bool = False
     ):
@@ -32,7 +32,7 @@ class ClaudeService(LLMService):
             split_chars=split_chars,
             option_split_chars=option_split_chars,
             option_split_threshold=option_split_threshold,
-            skip_before=skip_before,
+            voice_text_tag=voice_text_tag,
             context_manager=context_manager,
             debug=debug
         )

--- a/litests/llm/dify.py
+++ b/litests/llm/dify.py
@@ -19,7 +19,7 @@ class DifyService(LLMService):
         split_chars: List[str] = None,
         option_split_chars: List[str] = None,
         option_split_threshold: int = 50,
-        skip_before: str = None,
+        voice_text_tag: str = None,
         max_connections: int = 100,
         max_keepalive_connections: int = 20,
         timeout: float = 10.0
@@ -31,7 +31,7 @@ class DifyService(LLMService):
             split_chars=split_chars,
             option_split_chars=option_split_chars,
             option_split_threshold=option_split_threshold,
-            skip_before=skip_before
+            voice_text_tag=voice_text_tag
         )
         self.conversation_ids: Dict[str, str] = {}
         self.api_key = api_key

--- a/litests/llm/gemini.py
+++ b/litests/llm/gemini.py
@@ -18,7 +18,7 @@ class GeminiService(LLMService):
         split_chars: List[str] = None,
         option_split_chars: List[str] = None,
         option_split_threshold: int = 50,
-        skip_before: str = None,
+        voice_text_tag: str = None,
         context_manager: ContextManager = None,
         debug: bool = False
     ):
@@ -29,7 +29,7 @@ class GeminiService(LLMService):
             split_chars=split_chars,
             option_split_chars=option_split_chars,
             option_split_threshold=option_split_threshold,
-            skip_before=skip_before,
+            voice_text_tag=voice_text_tag,
             context_manager=context_manager,
             debug=debug
         )

--- a/litests/llm/litellm.py
+++ b/litests/llm/litellm.py
@@ -21,7 +21,7 @@ class LiteLLMService(LLMService):
         split_chars: List[str] = None,
         option_split_chars: List[str] = None,
         option_split_threshold: int = 50,
-        skip_before: str = None,
+        voice_text_tag: str = None,
         context_manager: ContextManager = None,
         debug: bool = False
     ):
@@ -32,7 +32,7 @@ class LiteLLMService(LLMService):
             split_chars=split_chars,
             option_split_chars=option_split_chars,
             option_split_threshold=option_split_threshold,
-            skip_before=skip_before,
+            voice_text_tag=voice_text_tag,
             context_manager=context_manager,
             debug=debug
         )

--- a/tests/llm/test_chatgpt.py
+++ b/tests/llm/test_chatgpt.py
@@ -86,7 +86,7 @@ async def test_chatgpt_service_cot():
         system_prompt=SYSTEM_PROMPT_COT,
         model=MODEL,
         temperature=0.5,
-        skip_before="<answer>"
+        voice_text_tag="answer"
     )
     context_id = f"test_cot_context_{uuid4()}"
 

--- a/tests/llm/test_chatgpt_azure.py
+++ b/tests/llm/test_chatgpt_azure.py
@@ -88,7 +88,7 @@ async def test_chatgpt_azure_service_cot():
         system_prompt=SYSTEM_PROMPT_COT,
         model="azure",
         temperature=0.5,
-        skip_before="<answer>"
+        voice_text_tag="answer"
     )
     context_id = f"test_cot_context_{uuid4()}"
 

--- a/tests/llm/test_claude.py
+++ b/tests/llm/test_claude.py
@@ -84,7 +84,7 @@ async def test_claude_service_cot():
         system_prompt=SYSTEM_PROMPT_COT,
         model=MODEL,
         temperature=0.5,
-        skip_before="<answer>"
+        voice_text_tag="answer"
     )
     context_id = f"test_context_cot_{uuid4()}"
 

--- a/tests/llm/test_gemini.py
+++ b/tests/llm/test_gemini.py
@@ -83,7 +83,7 @@ async def test_gemini_service_cot():
         system_prompt=SYSTEM_PROMPT_COT,
         model=MODEL,
         temperature=0.5,
-        skip_before="<answer>"
+        voice_text_tag="answer"
     )
     context_id = f"test_context_cot_{uuid4()}"
 

--- a/tests/llm/test_litellm.py
+++ b/tests/llm/test_litellm.py
@@ -84,7 +84,7 @@ async def test_litellm_service_cot():
         system_prompt=SYSTEM_PROMPT_COT,
         model=MODEL,
         temperature=0.5,
-        skip_before="<answer>"
+        voice_text_tag="answer"
     )
     context_id = f"test_context_cot_{uuid4()}"
 


### PR DESCRIPTION
Previously, we used the `skip_before` parameter to indicate that text following a specified marker (e.g. skip_before="<answer>") should be read aloud. With this change, we introduce the `voice_text_tag` parameter (e.g. voice_text_tag="answer") so that only the content enclosed within the <answer>...</answer> tags is synthesized for speech.

This update ensures that when responses contain multiple sections (such as both <thinking> and <answer> segments), only the answer portion is correctly extracted and read aloud.