### PR TITLE
Add metadata to response for better handling

### DIFF
--- a/litests/models.py
+++ b/litests/models.py
@@ -25,3 +25,4 @@ class STSResponse:
     voice_text: str = None
     audio_data: bytes = None
     tool_call: ToolCall = None
+    metadata: dict = None


### PR DESCRIPTION
- start: `request_text`
- chunk: is_first_chunk

NOTE: We don't include `request_files` because it may be so large and the clients know what file they sent.