### PR TITLE
Add support for custom dynamic tool repository

### DIFF
--- a/litests/llm/base.py
+++ b/litests/llm/base.py
@@ -86,6 +86,7 @@ If none apply, respond as follows:
 The list of tools is as follows:
 
 """
+        self._get_dynamic_tools = self.get_dynamic_tools_default
         self._on_before_tool_calls = self.on_before_tool_calls_default
         self.context_manager = context_manager or SQLiteContextManager()
         self.debug = debug
@@ -102,6 +103,10 @@ The list of tools is as follows:
         def decorator(func):
             return func
         return decorator
+
+    async def get_dynamic_tools(self, func):
+        self._get_dynamic_tools = func
+        return func
 
     def on_before_tool_calls(self, func):
         self._on_before_tool_calls = func
@@ -126,6 +131,9 @@ The list of tools is as follows:
     @abstractmethod
     async def update_context(self, context_id: str, messages: List[Dict], response_text: str):
         pass
+
+    async def get_dynamic_tools_default(self, messages: List[dict], metadata: Dict[str, any] = None) -> List[Dict[str, any]]:
+        return []
 
     @abstractmethod
     async def get_llm_stream_response(self, context_id: str, user_id: str, messages: List[dict], system_prompt_params: Dict[str, any] = None) -> AsyncGenerator[LLMResponse, None]:

--- a/litests/llm/chatgpt.py
+++ b/litests/llm/chatgpt.py
@@ -110,7 +110,7 @@ class ChatGPTService(LLMService):
             return func
         return decorator
 
-    async def get_dynamic_tool(self, messages: List[dict]) -> List[Dict[str, any]]:
+    async def get_dynamic_tools_default(self, messages: List[dict], metadata: Dict[str, any] = None) -> List[Dict[str, any]]:
         # Make additional prompt with registered tools
         tool_listing_prompt = self.additional_prompt_for_tool_listing
         for _, t in self.tools.items():
@@ -199,7 +199,7 @@ class ChatGPTService(LLMService):
                     tool_calls.append(ToolCall(t.id, t.function.name, ""))
                     if t.function.name == self.dynamic_tool_spec["function"]["name"]:
                         logger.info("Get dynamic tool")
-                        filtered_tools = await self.get_dynamic_tool(messages)
+                        filtered_tools = await self._get_dynamic_tools(messages)
                         logger.info(f"Dynamic tools: {filtered_tools}")
                         try_dynamic_tools = True
                 if t.function.arguments:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="litests",
-    version="0.3.11",
+    version="0.3.12",
     url="https://github.com/uezo/litests",
     author="uezo",
     author_email="uezo@uezo.net",

--- a/tests/llm/test_claude.py
+++ b/tests/llm/test_claude.py
@@ -240,9 +240,10 @@ async def test_claude_service_tool_calls():
     assert messages[0]["content"] == [{"type": "text", "text": user_message}]
 
     assert messages[1]["role"] == "assistant"
-    assert messages[1]["content"][0]["type"] == "tool_use"
-    assert messages[1]["content"][0]["name"] == "solve_math"
-    tool_use_id = messages[1]["content"][0]["id"]
+    tool_use_content_index = len(messages[1]["content"][0]) - 1
+    assert messages[1]["content"][tool_use_content_index]["type"] == "tool_use"
+    assert messages[1]["content"][tool_use_content_index]["name"] == "solve_math"
+    tool_use_id = messages[1]["content"][tool_use_content_index]["id"]
 
     assert messages[2]["role"] == "user"
     assert messages[2]["content"][0]["type"] == "tool_result"


### PR DESCRIPTION
You can use your implementation for getting dynamic tools.

```python
@chatgpt.get_dynamic_tools
async def my_get_dynamic_tools(messages, metadata) -> list:
    return tool_specs
```

Also, improved context management for Claude and Gemini👍